### PR TITLE
calltrace with rally

### DIFF
--- a/neutron/neutron/wsgi.py
+++ b/neutron/neutron/wsgi.py
@@ -1,0 +1,880 @@
+# Copyright 2011 OpenStack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+Utility methods for working with WSGI servers
+"""
+import errno
+import GreenletProfiler
+import os
+import socket
+import sys
+import time
+
+import eventlet.wsgi
+from neutron.conf import wsgi as wsgi_config
+from neutron_lib import exceptions as exception
+from oslo_config import cfg
+import oslo_i18n
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+from oslo_service import service as common_service
+from oslo_service import sslutils
+from oslo_service import systemd
+from oslo_service import wsgi
+from oslo_utils import encodeutils
+from oslo_utils import excutils
+import six
+import webob.dec
+import webob.exc
+
+from neutron._i18n import _, _LE, _LI
+from neutron.common import config
+from neutron.common import exceptions as n_exc
+from neutron.common import utils
+from neutron import context
+from neutron.db import api
+from neutron import worker as neutron_worker
+
+CONF = cfg.CONF
+wsgi_config.register_socket_opts()
+
+LOG = logging.getLogger(__name__)
+SERVER_BACKLOG = 4096
+
+
+def encode_body(body):
+    """Encode unicode body.
+
+    WebOb requires to encode unicode body used to update response body.
+    """
+    return encodeutils.to_utf8(body)
+
+
+class ProfilerHandler(object):
+    @webob.dec.wsgify(RequestClass=webob.Request)
+    def __call__(self, req):
+        filename = req.headers['X-Neutron-Profiler-Filename']
+        action = req.headers['X-Neutron-Profiler-Action']
+        if action == 'start_trace':
+            GreenletProfiler.set_clock_type('cpu')
+            GreenletProfiler.start()
+        else:
+            GreenletProfiler.stop()
+            stats = GreenletProfiler.get_func_stats()
+            stats.save(filename, 'pstat')
+            GreenletProfiler.clear_stats()
+
+
+class UnixDomainHttpProtocol(eventlet.wsgi.HttpProtocol):
+    # TODO(jlibosva): This is just a workaround not to set TCP_NODELAY on
+    # socket due to 40714b1ffadd47b315ca07f9b85009448f0fe63d evenlet change
+    # This should be removed once
+    # https://github.com/eventlet/eventlet/issues/301 is fixed
+    disable_nagle_algorithm = False
+
+    def __init__(self, request, client_address, server):
+        if client_address == '':
+            client_address = ('<local>', 0)
+        # base class is old-style, so super does not work properly
+        eventlet.wsgi.HttpProtocol.__init__(self, request, client_address,
+                                            server)
+
+
+class ProfilerListener(object):
+
+    @classmethod
+    def get_GreenletProfiler_trace_socket_path(cls):
+        path = os.path.join('/tmp', str(os.getpid()), 'sock')
+        utils.ensure_dir(os.path.dirname(path))
+        return path
+
+    def run(self):
+        server = UnixDomainWSGIServer(
+            'greenlet-profiler')
+        server.start(ProfilerHandler(),
+                     self.get_GreenletProfiler_trace_socket_path(),
+                     workers=0,
+                     backlog=SERVER_BACKLOG)
+        server.wait()
+
+
+class WorkerService(neutron_worker.NeutronWorker):
+    """Wraps a worker to be handled by ProcessLauncher"""
+    def __init__(self, service, application, disable_ssl=False,
+                 worker_process_count=0):
+        super(WorkerService, self).__init__(worker_process_count)
+
+        self._service = service
+        self._application = application
+        self._disable_ssl = disable_ssl
+        self._server = None
+
+    def _start_profiler_listener(self):
+        profiler_listener = ProfilerListener()
+        profiler_listener.run()
+
+    def start(self):
+        if self.worker_process_count > 0:
+            eventlet.spawn(self._start_profiler_listener)
+        super(WorkerService, self).start()
+        # When api worker is stopped it kills the eventlet wsgi server which
+        # internally closes the wsgi server socket object. This server socket
+        # object becomes not usable which leads to "Bad file descriptor"
+        # errors on service restart.
+        # Duplicate a socket object to keep a file descriptor usable.
+        dup_sock = self._service._socket.dup()
+        if CONF.use_ssl and not self._disable_ssl:
+            dup_sock = sslutils.wrap(CONF, dup_sock)
+        self._server = self._service.pool.spawn(self._service._run,
+                                                self._application,
+                                                dup_sock)
+
+    def wait(self):
+        if isinstance(self._server, eventlet.greenthread.GreenThread):
+            self._server.wait()
+
+    def stop(self):
+        if isinstance(self._server, eventlet.greenthread.GreenThread):
+            self._server.kill()
+            self._server = None
+
+    @staticmethod
+    def reset():
+        config.reset_service()
+
+
+class Server(object):
+    """Server class to manage multiple WSGI sockets and applications."""
+
+    def __init__(self, name, num_threads=None, disable_ssl=False):
+        # Raise the default from 8192 to accommodate large tokens
+        eventlet.wsgi.MAX_HEADER_LINE = CONF.max_header_line
+        self.num_threads = num_threads or CONF.wsgi_default_pool_size
+        self.disable_ssl = disable_ssl
+        # Pool for a greenthread in which wsgi server will be running
+        self.pool = eventlet.GreenPool(1)
+        self.name = name
+        self._server = None
+        # A value of 0 is converted to None because None is what causes the
+        # wsgi server to wait forever.
+        self.client_socket_timeout = CONF.client_socket_timeout or None
+        if CONF.use_ssl and not self.disable_ssl:
+            sslutils.is_enabled(CONF)
+
+    def _get_socket(self, host, port, backlog):
+        bind_addr = (host, port)
+        # TODO(dims): eventlet's green dns/socket module does not actually
+        # support IPv6 in getaddrinfo(). We need to get around this in the
+        # future or monitor upstream for a fix
+        try:
+            info = socket.getaddrinfo(bind_addr[0],
+                                      bind_addr[1],
+                                      socket.AF_UNSPEC,
+                                      socket.SOCK_STREAM)[0]
+            family = info[0]
+            bind_addr = info[-1]
+        except Exception:
+            LOG.exception(_LE("Unable to listen on %(host)s:%(port)s"),
+                          {'host': host, 'port': port})
+            sys.exit(1)
+
+        sock = None
+        retry_until = time.time() + CONF.retry_until_window
+        while not sock and time.time() < retry_until:
+            try:
+                sock = eventlet.listen(bind_addr,
+                                       backlog=backlog,
+                                       family=family)
+            except socket.error as err:
+                with excutils.save_and_reraise_exception() as ctxt:
+                    if err.errno == errno.EADDRINUSE:
+                        ctxt.reraise = False
+                        eventlet.sleep(0.1)
+        if not sock:
+            raise RuntimeError(_("Could not bind to %(host)s:%(port)s "
+                               "after trying for %(time)d seconds") %
+                               {'host': host,
+                                'port': port,
+                                'time': CONF.retry_until_window})
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # sockets can hang around forever without keepalive
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+        # This option isn't available in the OS X version of eventlet
+        if hasattr(socket, 'TCP_KEEPIDLE'):
+            sock.setsockopt(socket.IPPROTO_TCP,
+                            socket.TCP_KEEPIDLE,
+                            CONF.tcp_keepidle)
+
+        return sock
+
+    def start(self, application, port, host='0.0.0.0', workers=0):
+        """Run a WSGI server with the given application."""
+        self._host = host
+        self._port = port
+        backlog = CONF.backlog
+
+        self._socket = self._get_socket(self._host,
+                                        self._port,
+                                        backlog=backlog)
+
+        self._launch(application, workers)
+
+    def _launch(self, application, workers=0):
+        service = WorkerService(self, application, self.disable_ssl, workers)
+        if workers < 1:
+            # The API service should run in the current process.
+            self._server = service
+            # Dump the initial option values
+            cfg.CONF.log_opt_values(LOG, logging.DEBUG)
+            service.start()
+            systemd.notify_once()
+        else:
+            # dispose the whole pool before os.fork, otherwise there will
+            # be shared DB connections in child processes which may cause
+            # DB errors.
+            api.context_manager.dispose_pool()
+            # The API service runs in a number of child processes.
+            # Minimize the cost of checking for child exit by extending the
+            # wait interval past the default of 0.01s.
+            self._server = common_service.ProcessLauncher(cfg.CONF,
+                                                          wait_interval=1.0)
+            self._server.launch_service(service,
+                                        workers=service.worker_process_count)
+
+    @property
+    def host(self):
+        return self._socket.getsockname()[0] if self._socket else self._host
+
+    @property
+    def port(self):
+        return self._socket.getsockname()[1] if self._socket else self._port
+
+    def stop(self):
+        self._server.stop()
+
+    def wait(self):
+        """Wait until all servers have completed running."""
+        try:
+            self._server.wait()
+        except KeyboardInterrupt:
+            pass
+
+    def _run(self, application, socket):
+        """Start a WSGI server in a new green thread."""
+        eventlet.wsgi.server(socket, application,
+                             max_size=self.num_threads,
+                             log=LOG,
+                             keepalive=CONF.wsgi_keep_alive,
+                             socket_timeout=self.client_socket_timeout)
+
+
+class UnixDomainWSGIServer(Server):
+    def __init__(self, name, num_threads=None):
+        self._socket = None
+        self._launcher = None
+        self._server = None
+        super(UnixDomainWSGIServer, self).__init__(name, disable_ssl=True,
+                                                   num_threads=4)
+
+    def start(self, application, file_socket, workers, backlog, mode=None):
+        self._socket = eventlet.listen(file_socket,
+                                       family=socket.AF_UNIX,
+                                       backlog=backlog)
+        if mode is not None:
+            os.chmod(file_socket, mode)
+
+        self._launch(application, workers=workers)
+
+    def _run(self, application, socket):
+        """Start a WSGI service in a new green thread."""
+        logger = logging.getLogger('eventlet.wsgi.server')
+        eventlet.wsgi.server(socket,
+                             application,
+                             max_size=self.num_threads,
+                             protocol=UnixDomainHttpProtocol,
+                             log=logger)
+
+
+class Request(wsgi.Request):
+
+    def best_match_content_type(self):
+        """Determine the most acceptable content-type.
+
+        Based on:
+            1) URI extension (.json)
+            2) Content-type header
+            3) Accept* headers
+        """
+        # First lookup http request path
+        parts = self.path.rsplit('.', 1)
+        if len(parts) > 1:
+            _format = parts[1]
+            if _format in ['json']:
+                return 'application/{0}'.format(_format)
+
+        #Then look up content header
+        type_from_header = self.get_content_type()
+        if type_from_header:
+            return type_from_header
+        ctypes = ['application/json']
+
+        #Finally search in Accept-* headers
+        bm = self.accept.best_match(ctypes)
+        return bm or 'application/json'
+
+    def get_content_type(self):
+        allowed_types = ("application/json",)
+        if "Content-Type" not in self.headers:
+            LOG.debug("Missing Content-Type")
+            return None
+        _type = self.content_type
+        if _type in allowed_types:
+            return _type
+        return None
+
+    def best_match_language(self):
+        """Determines best available locale from the Accept-Language header.
+
+        :returns: the best language match or None if the 'Accept-Language'
+                  header was not available in the request.
+        """
+        if not self.accept_language:
+            return None
+        all_languages = oslo_i18n.get_available_languages('neutron')
+        return self.accept_language.best_match(all_languages)
+
+    @property
+    def context(self):
+        if 'neutron.context' not in self.environ:
+            self.environ['neutron.context'] = context.get_admin_context()
+        return self.environ['neutron.context']
+
+
+class ActionDispatcher(object):
+    """Maps method name to local methods through action name."""
+
+    def dispatch(self, *args, **kwargs):
+        """Find and call local method."""
+        action = kwargs.pop('action', 'default')
+        action_method = getattr(self, str(action), self.default)
+        return action_method(*args, **kwargs)
+
+    def default(self, data):
+        raise NotImplementedError()
+
+
+class DictSerializer(ActionDispatcher):
+    """Default request body serialization."""
+
+    def serialize(self, data, action='default'):
+        return self.dispatch(data, action=action)
+
+    def default(self, data):
+        return ""
+
+
+class JSONDictSerializer(DictSerializer):
+    """Default JSON request body serialization."""
+
+    def default(self, data):
+        def sanitizer(obj):
+            return six.text_type(obj)
+        return encode_body(jsonutils.dumps(data, default=sanitizer))
+
+
+class ResponseHeaderSerializer(ActionDispatcher):
+    """Default response headers serialization."""
+
+    def serialize(self, response, data, action):
+        self.dispatch(response, data, action=action)
+
+    def default(self, response, data):
+        response.status_int = 200
+
+
+class ResponseSerializer(object):
+    """Encode the necessary pieces into a response object."""
+
+    def __init__(self, body_serializers=None, headers_serializer=None):
+        self.body_serializers = {
+            'application/json': JSONDictSerializer(),
+        }
+        self.body_serializers.update(body_serializers or {})
+
+        self.headers_serializer = (headers_serializer or
+                                   ResponseHeaderSerializer())
+
+    def serialize(self, response_data, content_type, action='default'):
+        """Serialize a dict into a string and wrap in a wsgi.Request object.
+
+        :param response_data: dict produced by the Controller
+        :param content_type: expected mimetype of serialized response body
+
+        """
+        response = webob.Response()
+        self.serialize_headers(response, response_data, action)
+        self.serialize_body(response, response_data, content_type, action)
+        return response
+
+    def serialize_headers(self, response, data, action):
+        self.headers_serializer.serialize(response, data, action)
+
+    def serialize_body(self, response, data, content_type, action):
+        response.headers['Content-Type'] = content_type
+        if data is not None:
+            serializer = self.get_body_serializer(content_type)
+            response.body = serializer.serialize(data, action)
+
+    def get_body_serializer(self, content_type):
+        try:
+            return self.body_serializers[content_type]
+        except (KeyError, TypeError):
+            raise exception.InvalidContentType(content_type=content_type)
+
+
+class TextDeserializer(ActionDispatcher):
+    """Default request body deserialization."""
+
+    def deserialize(self, datastring, action='default'):
+        return self.dispatch(datastring, action=action)
+
+    def default(self, datastring):
+        return {}
+
+
+class JSONDeserializer(TextDeserializer):
+
+    def _from_json(self, datastring):
+        try:
+            return jsonutils.loads(datastring)
+        except ValueError:
+            msg = _("Cannot understand JSON")
+            raise n_exc.MalformedRequestBody(reason=msg)
+
+    def default(self, datastring):
+        return {'body': self._from_json(datastring)}
+
+
+class RequestHeadersDeserializer(ActionDispatcher):
+    """Default request headers deserializer."""
+
+    def deserialize(self, request, action):
+        return self.dispatch(request, action=action)
+
+    def default(self, request):
+        return {}
+
+
+class RequestDeserializer(object):
+    """Break up a Request object into more useful pieces."""
+
+    def __init__(self, body_deserializers=None, headers_deserializer=None):
+        self.body_deserializers = {
+            'application/json': JSONDeserializer(),
+        }
+        self.body_deserializers.update(body_deserializers or {})
+
+        self.headers_deserializer = (headers_deserializer or
+                                     RequestHeadersDeserializer())
+
+    def deserialize(self, request):
+        """Extract necessary pieces of the request.
+
+        :param request: Request object
+        :returns tuple of expected controller action name, dictionary of
+                 keyword arguments to pass to the controller, the expected
+                 content type of the response
+
+        """
+        action_args = self.get_action_args(request.environ)
+        action = action_args.pop('action', None)
+
+        action_args.update(self.deserialize_headers(request, action))
+        action_args.update(self.deserialize_body(request, action))
+
+        accept = self.get_expected_content_type(request)
+
+        return (action, action_args, accept)
+
+    def deserialize_headers(self, request, action):
+        return self.headers_deserializer.deserialize(request, action)
+
+    def deserialize_body(self, request, action):
+        try:
+            content_type = request.best_match_content_type()
+        except exception.InvalidContentType:
+            LOG.debug("Unrecognized Content-Type provided in request")
+            return {}
+
+        if content_type is None:
+            LOG.debug("No Content-Type provided in request")
+            return {}
+
+        if not len(request.body) > 0:
+            LOG.debug("Empty body provided in request")
+            return {}
+
+        try:
+            deserializer = self.get_body_deserializer(content_type)
+        except exception.InvalidContentType:
+            with excutils.save_and_reraise_exception():
+                LOG.debug("Unable to deserialize body as provided "
+                          "Content-Type")
+
+        return deserializer.deserialize(request.body, action)
+
+    def get_body_deserializer(self, content_type):
+        try:
+            return self.body_deserializers[content_type]
+        except (KeyError, TypeError):
+            raise exception.InvalidContentType(content_type=content_type)
+
+    def get_expected_content_type(self, request):
+        return request.best_match_content_type()
+
+    def get_action_args(self, request_environment):
+        """Parse dictionary created by routes library."""
+        try:
+            args = request_environment['wsgiorg.routing_args'][1].copy()
+        except Exception:
+            return {}
+
+        try:
+            del args['controller']
+        except KeyError:
+            pass
+
+        try:
+            del args['format']
+        except KeyError:
+            pass
+
+        return args
+
+
+class Application(object):
+    """Base WSGI application wrapper. Subclasses need to implement __call__."""
+
+    @classmethod
+    def factory(cls, global_config, **local_config):
+        """Used for paste app factories in paste.deploy config files.
+
+        Any local configuration (that is, values under the [app:APPNAME]
+        section of the paste config) will be passed into the `__init__` method
+        as kwargs.
+
+        A hypothetical configuration would look like:
+
+            [app:wadl]
+            latest_version = 1.3
+            paste.app_factory = nova.api.fancy_api:Wadl.factory
+
+        which would result in a call to the `Wadl` class as
+
+            import neutron.api.fancy_api
+            fancy_api.Wadl(latest_version='1.3')
+
+        You could of course re-implement the `factory` method in subclasses,
+        but using the kwarg passing it shouldn't be necessary.
+
+        """
+        return cls(**local_config)
+
+    def __call__(self, environ, start_response):
+        r"""Subclasses will probably want to implement __call__ like this:
+
+        @webob.dec.wsgify(RequestClass=Request)
+        def __call__(self, req):
+          # Any of the following objects work as responses:
+
+          # Option 1: simple string
+          res = 'message\n'
+
+          # Option 2: a nicely formatted HTTP exception page
+          res = exc.HTTPForbidden(explanation='Nice try')
+
+          # Option 3: a webob Response object (in case you need to play with
+          # headers, or you want to be treated like an iterable, or or or)
+          res = Response();
+          res.app_iter = open('somefile')
+
+          # Option 4: any wsgi app to be run next
+          res = self.application
+
+          # Option 5: you can get a Response object for a wsgi app, too, to
+          # play with headers etc
+          res = req.get_response(self.application)
+
+          # You can then just return your response...
+          return res
+          # ... or set req.response and return None.
+          req.response = res
+
+        See the end of http://pythonpaste.org/webob/modules/dec.html
+        for more info.
+
+        """
+        raise NotImplementedError(_('You must implement __call__'))
+
+
+class Resource(Application):
+    """WSGI app that handles (de)serialization and controller dispatch.
+
+    WSGI app that reads routing information supplied by RoutesMiddleware
+    and calls the requested action method upon its controller.  All
+    controller action methods must accept a 'req' argument, which is the
+    incoming wsgi.Request. If the operation is a PUT or POST, the controller
+    method must also accept a 'body' argument (the deserialized request body).
+    They may raise a webob.exc exception or return a dict, which will be
+    serialized by requested content type.
+
+    """
+
+    def __init__(self, controller, fault_body_function,
+                 deserializer=None, serializer=None):
+        """Object initialization.
+
+        :param controller: object that implement methods created by routes lib
+        :param deserializer: object that can serialize the output of a
+                             controller into a webob response
+        :param serializer: object that can deserialize a webob request
+                           into necessary pieces
+        :param fault_body_function: a function that will build the response
+                                    body for HTTP errors raised by operations
+                                    on this resource object
+
+        """
+        self.controller = controller
+        self.deserializer = deserializer or RequestDeserializer()
+        self.serializer = serializer or ResponseSerializer()
+        self._fault_body_function = fault_body_function
+
+    @webob.dec.wsgify(RequestClass=Request)
+    def __call__(self, request):
+        """WSGI method that controls (de)serialization and method dispatch."""
+
+        LOG.info(_LI("%(method)s %(url)s"),
+                 {"method": request.method, "url": request.url})
+
+        try:
+            action, args, accept = self.deserializer.deserialize(request)
+        except exception.InvalidContentType:
+            msg = _("Unsupported Content-Type")
+            LOG.exception(_LE("InvalidContentType: %s"), msg)
+            return Fault(webob.exc.HTTPBadRequest(explanation=msg))
+        except n_exc.MalformedRequestBody:
+            msg = _("Malformed request body")
+            LOG.exception(_LE("MalformedRequestBody: %s"), msg)
+            return Fault(webob.exc.HTTPBadRequest(explanation=msg))
+
+        try:
+            action_result = self.dispatch(request, action, args)
+        except webob.exc.HTTPException as ex:
+            LOG.info(_LI("HTTP exception thrown: %s"), ex)
+            action_result = Fault(ex, self._fault_body_function)
+        except Exception:
+            LOG.exception(_LE("Internal error"))
+            # Do not include the traceback to avoid returning it to clients.
+            action_result = Fault(webob.exc.HTTPServerError(),
+                                  self._fault_body_function)
+
+        if isinstance(action_result, dict) or action_result is None:
+            response = self.serializer.serialize(action_result,
+                                                 accept,
+                                                 action=action)
+        else:
+            response = action_result
+
+        try:
+            LOG.info(_LI("%(url)s returned with HTTP %(status)d"),
+                     dict(url=request.url, status=response.status_int))
+        except AttributeError as e:
+            LOG.info(_LI("%(url)s returned a fault: %(exception)s"),
+                     dict(url=request.url, exception=e))
+
+        return response
+
+    def dispatch(self, request, action, action_args):
+        """Find action-specific method on controller and call it."""
+
+        controller_method = getattr(self.controller, action)
+        try:
+            #NOTE(salvatore-orlando): the controller method must have
+            # an argument whose name is 'request'
+            return controller_method(request=request, **action_args)
+        except TypeError:
+            LOG.exception(_LE('Invalid request'))
+            return Fault(webob.exc.HTTPBadRequest())
+
+
+def _default_body_function(wrapped_exc):
+    code = wrapped_exc.status_int
+    fault_data = {
+        'Error': {
+            'code': code,
+            'message': wrapped_exc.explanation}}
+    # 'code' is an attribute on the fault tag itself
+    metadata = {'attributes': {'Error': 'code'}}
+    return fault_data, metadata
+
+
+class Fault(webob.exc.HTTPException):
+    """Generates an HTTP response from a webob HTTP exception."""
+
+    def __init__(self, exception, body_function=None):
+        """Creates a Fault for the given webob.exc.exception."""
+        self.wrapped_exc = exception
+        self.status_int = self.wrapped_exc.status_int
+        self._body_function = body_function or _default_body_function
+
+    @webob.dec.wsgify(RequestClass=Request)
+    def __call__(self, req):
+        """Generate a WSGI response based on the exception passed to ctor."""
+        # Replace the body with fault details.
+        fault_data, metadata = self._body_function(self.wrapped_exc)
+        content_type = req.best_match_content_type()
+        serializer = {
+            'application/json': JSONDictSerializer(),
+        }[content_type]
+
+        self.wrapped_exc.body = serializer.serialize(fault_data)
+        self.wrapped_exc.content_type = content_type
+        return self.wrapped_exc
+
+
+# NOTE(salvatore-orlando): this class will go once the
+# extension API framework is updated
+class Controller(object):
+    """WSGI app that dispatched to methods.
+
+    WSGI app that reads routing information supplied by RoutesMiddleware
+    and calls the requested action method upon itself.  All action methods
+    must, in addition to their normal parameters, accept a 'req' argument
+    which is the incoming wsgi.Request.  They raise a webob.exc exception,
+    or return a dict which will be serialized by requested content type.
+
+    """
+
+    @webob.dec.wsgify(RequestClass=Request)
+    def __call__(self, req):
+        """Call the method specified in req.environ by RoutesMiddleware."""
+        arg_dict = req.environ['wsgiorg.routing_args'][1]
+        action = arg_dict['action']
+        method = getattr(self, action)
+        del arg_dict['controller']
+        del arg_dict['action']
+        if 'format' in arg_dict:
+            del arg_dict['format']
+        arg_dict['request'] = req
+        result = method(**arg_dict)
+
+        if isinstance(result, dict) or result is None:
+            if result is None:
+                status = 204
+                content_type = ''
+                body = None
+            else:
+                status = 200
+                content_type = req.best_match_content_type()
+                body = self._serialize(result, content_type)
+
+            response = webob.Response(status=status,
+                                      content_type=content_type,
+                                      body=body)
+            LOG.debug("%(url)s returned with HTTP %(status)d",
+                      dict(url=req.url, status=response.status_int))
+            return response
+        else:
+            return result
+
+    def _serialize(self, data, content_type):
+        """Serialize the given dict to the provided content_type.
+
+        Uses self._serialization_metadata if it exists, which is a dict mapping
+        MIME types to information needed to serialize to that type.
+
+        """
+        _metadata = getattr(type(self), '_serialization_metadata', {})
+
+        serializer = Serializer(_metadata)
+        try:
+            return serializer.serialize(data, content_type)
+        except exception.InvalidContentType:
+            msg = _('The requested content type %s is invalid.') % content_type
+            raise webob.exc.HTTPNotAcceptable(msg)
+
+    def _deserialize(self, data, content_type):
+        """Deserialize the request body to the specified content type.
+
+        Uses self._serialization_metadata if it exists, which is a dict mapping
+        MIME types to information needed to serialize to that type.
+
+        """
+        _metadata = getattr(type(self), '_serialization_metadata', {})
+        serializer = Serializer(_metadata)
+        return serializer.deserialize(data, content_type)['body']
+
+
+# NOTE(salvatore-orlando): this class will go once the
+# extension API framework is updated
+class Serializer(object):
+    """Serializes and deserializes dictionaries to certain MIME types."""
+
+    def __init__(self, metadata=None):
+        """Create a serializer based on the given WSGI environment.
+
+        'metadata' is an optional dict mapping MIME types to information
+        needed to serialize a dictionary to that type.
+
+        """
+        self.metadata = metadata or {}
+
+    def _get_serialize_handler(self, content_type):
+        handlers = {
+            'application/json': JSONDictSerializer(),
+        }
+
+        try:
+            return handlers[content_type]
+        except Exception:
+            raise exception.InvalidContentType(content_type=content_type)
+
+    def serialize(self, data, content_type):
+        """Serialize a dictionary into the specified content type."""
+        return self._get_serialize_handler(content_type).serialize(data)
+
+    def deserialize(self, datastring, content_type):
+        """Deserialize a string to a dictionary.
+
+        The string must be in the format of a supported MIME type.
+
+        """
+        try:
+            return self.get_deserialize_handler(content_type).deserialize(
+                datastring)
+        except Exception:
+            raise webob.exc.HTTPBadRequest(_("Could not deserialize data"))
+
+    def get_deserialize_handler(self, content_type):
+        handlers = {
+            'application/json': JSONDeserializer(),
+        }
+
+        try:
+            return handlers[content_type]
+        except Exception:
+            raise exception.InvalidContentType(content_type=content_type)

--- a/rally/rally/task/engine.py
+++ b/rally/rally/task/engine.py
@@ -1,0 +1,742 @@
+# Copyright 2013: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import copy
+import httplib2
+import json
+import jsonschema
+import os
+import pstats
+import requests
+import six
+import socket
+import threading
+import time
+import traceback
+
+from oslo_utils import fileutils
+from six.moves import http_client as httplib
+
+
+from rally.common.i18n import _
+from rally.common import logging
+from rally.common import objects
+from rally.common import utils
+from rally import consts
+from rally import exceptions
+from rally import osclients
+from rally.plugins.openstack.context.keystone import existing_users
+from rally.plugins.openstack.context.keystone import users as users_ctx
+from rally.task import context
+from rally.task import hook
+from rally.task import runner
+from rally.task import scenario
+from rally.task import sla
+
+
+LOG = logging.getLogger(__name__)
+
+sock_path = '/tmp/sock'
+pids = ['28776', '28777']
+
+
+def set_socket_path(path):
+    global sock_path
+    sock_path = path
+
+
+def get_socket_path():
+    global sock_path
+    return sock_path
+
+
+class UnixDomainHTTPConnection(httplib.HTTPConnection):
+    """Connection class for HTTP over UNIX domain socket."""
+    def __init__(self, host, port=None, strict=None, timeout=None,
+                 proxy_info=None):
+        httplib.HTTPConnection.__init__(self, host, port, strict)
+        self.timeout = timeout
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if self.timeout:
+            self.sock.settimeout(self.timeout)
+        self.sock.connect(self.socket_path)
+
+
+class KeepalivedUnixDomainConnection(UnixDomainHTTPConnection):
+    def __init__(self, *args, **kwargs):
+        # Old style super initialization is required!
+        UnixDomainHTTPConnection.__init__(
+            self, *args, **kwargs)
+        self.socket_path = get_socket_path()
+
+
+def notify_agent(file_name, action):
+    resp, content = httplib2.Http().request(
+    # Note that the message is sent via a Unix domain socket so that
+    # the URL doesn't matter.
+        'http://127.0.0.1/',
+        headers={'X-Neutron-Profiler-Filename': file_name,
+                 'X-Neutron-Profiler-Action': action},
+        connection_type=KeepalivedUnixDomainConnection)
+
+    if resp.status != requests.codes.ok:
+        raise Exception(_('Unexpected response: %s') % resp)
+
+
+def set_trace(action, file_name):
+    global pids
+    for pid in pids:
+        sock = os.path.join('/tmp', pid, 'sock')
+        set_socket_path(sock)
+        file_path = os.path.join('/tmp', pid, file_name)
+        notify_agent(file_path, action)
+
+
+def write_trace_to_file(taskid):
+    global pids
+    pid_files = []
+    for pid in pids:
+        pid_files.append(os.path.join('/tmp', pid, taskid))
+
+    tracefile = os.path.join("/tmp/rally/", taskid, "calltrace")
+    fileutils.ensure_tree(os.path.dirname(tracefile), mode=0o755)
+    with open(tracefile, "w+") as f:
+        for position, item in enumerate(pid_files):
+            if position == 0:
+                stats = pstats.Stats(item, stream=f)
+            else:
+                stats.add(item)
+        stats.sort_stats('cumulative')
+        stats.print_stats('neutron')
+
+
+class ResultConsumer(object):
+    """ResultConsumer class stores results from ScenarioRunner, checks SLA.
+
+    Also ResultConsumer listens for runner events and notifies HookExecutor
+    about started iterations.
+    """
+
+    def __init__(self, key, task, subtask, workload, runner,
+                 abort_on_sla_failure):
+        """ResultConsumer constructor.
+
+        :param key: Scenario identifier
+        :param task: Instance of Task, task to run
+        :param subtask: Instance of Subtask
+        :param workload: Instance of Workload
+        :param runner: ScenarioRunner instance that produces results to be
+                       consumed
+        :param abort_on_sla_failure: True if the execution should be stopped
+                                     when some SLA check fails
+        """
+
+        self.key = key
+        self.task = task
+        self.subtask = subtask
+        self.workload = workload
+        self.runner = runner
+        self.load_started_at = float("inf")
+        self.load_finished_at = 0
+
+        self.sla_checker = sla.SLAChecker(key["kw"])
+        self.hook_executor = hook.HookExecutor(key["kw"], self.task)
+        self.abort_on_sla_failure = abort_on_sla_failure
+        self.is_done = threading.Event()
+        self.unexpected_failure = {}
+        self.results = []
+        self.thread = threading.Thread(target=self._consume_results)
+        self.aborting_checker = threading.Thread(target=self.wait_and_abort)
+        if "hooks" in self.key["kw"]:
+            self.event_thread = threading.Thread(target=self._consume_events)
+
+    def __enter__(self):
+        self.thread.start()
+        self.aborting_checker.start()
+        if "hooks" in self.key["kw"]:
+            self.event_thread.start()
+        self.start = time.time()
+        set_trace('start_trace', self.task["uuid"])
+        return self
+
+    def _consume_results(self):
+        task_aborted = False
+        while True:
+            if self.runner.result_queue:
+                results = self.runner.result_queue.popleft()
+                self.results.extend(results)
+                for r in results:
+                    self.load_started_at = min(r["timestamp"],
+                                               self.load_started_at)
+                    self.load_finished_at = max(r["duration"] + r["timestamp"],
+                                                self.load_finished_at)
+                    success = self.sla_checker.add_iteration(r)
+                    if (self.abort_on_sla_failure and
+                            not success and
+                            not task_aborted):
+                        self.sla_checker.set_aborted_on_sla()
+                        self.runner.abort()
+                        self.task.update_status(
+                            consts.TaskStatus.SOFT_ABORTING)
+                        task_aborted = True
+            elif self.is_done.isSet():
+                break
+            else:
+                time.sleep(0.1)
+
+    def _consume_events(self):
+        while not self.is_done.isSet() or self.runner.event_queue:
+            if self.runner.event_queue:
+                event = self.runner.event_queue.popleft()
+                self.hook_executor.on_event(
+                    event_type=event["type"], value=event["value"])
+            else:
+                time.sleep(0.01)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.finish = time.time()
+        self.is_done.set()
+        self.aborting_checker.join()
+        self.thread.join()
+
+        if exc_type:
+            self.sla_checker.set_unexpected_failure(exc_value)
+
+        if objects.Task.get_status(
+                self.task["uuid"]) == consts.TaskStatus.ABORTED:
+            self.sla_checker.set_aborted_manually()
+
+        # NOTE(boris-42): Sort in order of starting instead of order of ending
+        self.results.sort(key=lambda x: x["timestamp"])
+
+        load_duration = max(self.load_finished_at - self.load_started_at, 0)
+
+        LOG.info("Load duration is: %s" % utils.format_float_to_str(
+            load_duration))
+        LOG.info("Full runner duration is: %s" %
+                 utils.format_float_to_str(self.runner.run_duration))
+        LOG.info("Full duration is %s" % utils.format_float_to_str(
+            self.finish - self.start))
+
+        results = {
+            "load_duration": load_duration,
+            "full_duration": self.finish - self.start,
+            "sla": self.sla_checker.results(),
+        }
+        self.runner.send_event(type="load_finished", value=results)
+        if "hooks" in self.key["kw"]:
+            self.event_thread.join()
+            results["hooks"] = self.hook_executor.results()
+        set_trace('stop_trace', self.task["uuid"])
+        write_trace_to_file(self.task["uuid"])
+        self.workload.add_workload_data({"raw": self.results})
+        self.workload.set_results(results)
+
+    @staticmethod
+    def is_task_in_aborting_status(task_uuid, check_soft=True):
+        """Checks task is in abort stages
+
+        :param task_uuid: UUID of task to check status
+        :type task_uuid: str
+        :param check_soft: check or not SOFT_ABORTING status
+        :type check_soft: bool
+        """
+        stages = [consts.TaskStatus.ABORTING, consts.TaskStatus.ABORTED]
+        if check_soft:
+            stages.append(consts.TaskStatus.SOFT_ABORTING)
+        return objects.Task.get_status(task_uuid) in stages
+
+    def wait_and_abort(self):
+        """Waits until abort signal is received and aborts runner in this case.
+
+        Has to be run from different thread simultaneously with the
+        runner.run method.
+        """
+
+        while not self.is_done.isSet():
+            if self.is_task_in_aborting_status(self.task["uuid"],
+                                               check_soft=False):
+                self.runner.abort()
+                self.task.update_status(consts.TaskStatus.ABORTED)
+                break
+            time.sleep(2.0)
+
+
+class TaskEngine(object):
+    """The Task engine class is used to execute benchmark scenarios.
+
+    An instance of this class is initialized by the API with the task
+    configuration and then is used to validate and execute all specified
+    in config subtasks.
+
+    .. note::
+
+        Typical usage:
+            ...
+            admin = ....  # contains dict representations of objects.Credential
+                          # with OpenStack admin credentials
+
+            users = ....  # contains a list of dicts of representations of
+                          # objects.Credential with OpenStack users credentials
+
+            engine = TaskEngine(config, task, admin=admin, users=users)
+            engine.validate()   # to test config
+            engine.run()        # to run config
+    """
+
+    def __init__(self, config, task, admin=None, users=None,
+                 abort_on_sla_failure=False):
+        """TaskEngine constructor.
+
+        :param config: Dict with configuration of specified benchmark scenarios
+        :param task: Instance of Task,
+                     the current task which is being performed
+        :param admin: Dict with admin credentials
+        :param users: List of dicts with user credentials
+        :param abort_on_sla_failure: True if the execution should be stopped
+                                     when some SLA check fails
+        """
+        try:
+            self.config = TaskConfig(config)
+        except Exception as e:
+            task.set_failed(type(e).__name__,
+                            str(e),
+                            json.dumps(traceback.format_exc()))
+            raise exceptions.InvalidTaskException(str(e))
+
+        self.task = task
+        self.admin = admin and objects.Credential(**admin) or None
+        self.existing_users = users or []
+        self.abort_on_sla_failure = abort_on_sla_failure
+
+    @logging.log_task_wrapper(LOG.info, _("Task validation check cloud."))
+    def _check_cloud(self):
+        clients = osclients.Clients(self.admin)
+        clients.verified_keystone()
+
+    @logging.log_task_wrapper(LOG.info,
+                              _("Task validation of scenarios names."))
+    def _validate_config_scenarios_name(self, config):
+        available = set(s.get_name() for s in scenario.Scenario.get_all())
+
+        specified = set()
+        for subtask in config.subtasks:
+            for s in subtask.workloads:
+                specified.add(s.name)
+
+        if not specified.issubset(available):
+            names = ", ".join(specified - available)
+            raise exceptions.NotFoundScenarios(names=names)
+
+    @logging.log_task_wrapper(LOG.info, _("Task validation of syntax."))
+    def _validate_config_syntax(self, config):
+        for subtask in config.subtasks:
+            for pos, workload in enumerate(subtask.workloads):
+                try:
+                    runner.ScenarioRunner.validate(workload.runner)
+                    context.ContextManager.validate(
+                        workload.context, non_hidden=True)
+                    sla.SLA.validate(workload.sla)
+                    for hook_conf in workload.hooks:
+                        hook.Hook.validate(hook_conf)
+                except (exceptions.RallyException,
+                        jsonschema.ValidationError) as e:
+
+                    kw = workload.make_exception_args(
+                        pos, six.text_type(e))
+                    raise exceptions.InvalidTaskConfig(**kw)
+
+    def _validate_config_semantic_helper(self, admin, user, workload, pos,
+                                         deployment):
+        try:
+            scenario.Scenario.validate(
+                workload.name, workload.to_dict(),
+                admin=admin, users=[user], deployment=deployment)
+        except exceptions.InvalidScenarioArgument as e:
+            kw = workload.make_exception_args(pos, six.text_type(e))
+            raise exceptions.InvalidTaskConfig(**kw)
+
+    def _get_user_ctx_for_validation(self, ctx):
+        if self.existing_users:
+            ctx["config"] = {"existing_users": self.existing_users}
+            user_context = existing_users.ExistingUsers(ctx)
+        else:
+            user_context = users_ctx.UserGenerator(ctx)
+
+        return user_context
+
+    @logging.log_task_wrapper(LOG.info, _("Task validation of semantic."))
+    def _validate_config_semantic(self, config):
+        self._check_cloud()
+
+        ctx_conf = {"task": self.task, "admin": {"credential": self.admin}}
+        deployment = objects.Deployment.get(self.task["deployment_uuid"])
+
+        # TODO(boris-42): It's quite hard at the moment to validate case
+        #                 when both user context and existing_users are
+        #                 specified. So after switching to plugin base
+        #                 and refactoring validation mechanism this place
+        #                 will be replaced
+        with self._get_user_ctx_for_validation(ctx_conf) as ctx:
+            ctx.setup()
+            admin = osclients.Clients(self.admin)
+            user = osclients.Clients(ctx_conf["users"][0]["credential"])
+
+            for u in ctx_conf["users"]:
+                user = osclients.Clients(u["credential"])
+                for subtask in config.subtasks:
+                    for pos, workload in enumerate(subtask.workloads):
+                        self._validate_config_semantic_helper(
+                            admin, user, workload,
+                            pos, deployment)
+
+    @logging.log_task_wrapper(LOG.info, _("Task validation."))
+    def validate(self):
+        """Perform full task configuration validation."""
+        self.task.update_status(consts.TaskStatus.VERIFYING)
+        try:
+            self._validate_config_scenarios_name(self.config)
+            self._validate_config_syntax(self.config)
+            self._validate_config_semantic(self.config)
+        except Exception as e:
+            exception_info = json.dumps(traceback.format_exc(), indent=2)
+            self.task.set_failed(type(e).__name__,
+                                 str(e), exception_info)
+            LOG.debug(exception_info)
+            raise exceptions.InvalidTaskException(str(e))
+
+    def _get_runner(self, config):
+        config = config or {"type": "serial"}
+        return runner.ScenarioRunner.get(config["type"])(self.task, config)
+
+    def _prepare_context(self, ctx, name, credential):
+        scenario_context = copy.deepcopy(
+            scenario.Scenario.get(name)._meta_get("default_context"))
+        if self.existing_users and "users" not in ctx:
+            scenario_context.setdefault("existing_users", self.existing_users)
+        elif "users" not in ctx:
+            scenario_context.setdefault("users", {})
+
+        scenario_context.update(ctx)
+        context_obj = {
+            "task": self.task,
+            "admin": {"credential": credential},
+            "scenario_name": name,
+            "config": scenario_context
+        }
+
+        return context_obj
+
+    @logging.log_task_wrapper(LOG.info, _("Benchmarking."))
+    def run(self):
+        """Run the benchmark according to the test configuration.
+
+        Test configuration is specified on engine initialization.
+
+        :returns: List of dicts, each dict containing the results of all the
+                  corresponding benchmark test launches
+        """
+        self.task.update_status(consts.TaskStatus.RUNNING)
+
+        for subtask in self.config.subtasks:
+            subtask_obj = self.task.add_subtask(**subtask.to_dict())
+
+            for pos, workload in enumerate(subtask.workloads):
+
+                if ResultConsumer.is_task_in_aborting_status(
+                        self.task["uuid"]):
+                    LOG.info("Received aborting signal.")
+                    self.task.update_status(consts.TaskStatus.ABORTED)
+                    return
+
+                key = workload.make_key(pos)
+                workload_obj = subtask_obj.add_workload(key)
+                LOG.info("Running benchmark with key: \n%s"
+                         % json.dumps(key, indent=2))
+                runner_obj = self._get_runner(workload.runner)
+                context_obj = self._prepare_context(
+                    workload.context, workload.name, self.admin)
+                try:
+                    with ResultConsumer(key, self.task,
+                                        subtask_obj, workload_obj, runner_obj,
+                                        self.abort_on_sla_failure):
+                        with context.ContextManager(context_obj):
+                            runner_obj.run(workload.name, context_obj,
+                                           workload.args)
+                except Exception as e:
+                    LOG.debug(traceback.format_exc())
+                    LOG.exception(e)
+
+        if objects.Task.get_status(
+                self.task["uuid"]) != consts.TaskStatus.ABORTED:
+            self.task.update_status(consts.TaskStatus.FINISHED)
+
+
+class TaskConfig(object):
+    """Version-aware wrapper around task.
+
+    """
+
+    HOOK_CONFIG = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "description": {"type": "string"},
+            "args": {},
+            "trigger": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "args": {},
+                },
+                "required": ["name", "args"],
+                "additionalProperties": False,
+            }
+        },
+        "required": ["name", "args", "trigger"],
+        "additionalProperties": False,
+    }
+
+    CONFIG_SCHEMA_V1 = {
+        "type": "object",
+        "$schema": consts.JSON_SCHEMA,
+        "patternProperties": {
+            ".*": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "args": {"type": "object"},
+                        "runner": {
+                            "type": "object",
+                            "properties": {"type": {"type": "string"}},
+                            "required": ["type"]
+                        },
+                        "context": {"type": "object"},
+                        "sla": {"type": "object"},
+                        "hooks": {
+                            "type": "array",
+                            "items": HOOK_CONFIG,
+                        }
+                    },
+                    "additionalProperties": False
+                }
+            }
+        }
+    }
+
+    CONFIG_SCHEMA_V2 = {
+        "type": "object",
+        "$schema": consts.JSON_SCHEMA,
+        "properties": {
+            "version": {"type": "number"},
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"}
+            },
+
+            "subtasks": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "group": {"type": "string"},
+                        "description": {"type": "string"},
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+
+                        "run_in_parallel": {"type": "boolean"},
+                        "workloads": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "args": {"type": "object"},
+
+                                    "runner": {
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {"type": "string"}
+                                        },
+                                        "required": ["type"]
+                                    },
+
+                                    "sla": {"type": "object"},
+                                    "hooks": {
+                                        "type": "array",
+                                        "items": HOOK_CONFIG,
+                                    },
+                                    "context": {"type": "object"}
+                                },
+                                "additionalProperties": False,
+                                "required": ["name", "runner"]
+                            }
+                        }
+                    },
+                    "additionalProperties": False,
+                    "required": ["title", "workloads"]
+                }
+            }
+        },
+        "additionalProperties": False,
+        "required": ["title", "subtasks"]
+    }
+
+    CONFIG_SCHEMAS = {1: CONFIG_SCHEMA_V1, 2: CONFIG_SCHEMA_V2}
+
+    def __init__(self, config):
+        """TaskConfig constructor.
+
+        :param config: Dict with configuration of specified task
+        """
+        if config is None:
+            # NOTE(stpierre): This gets reraised as
+            # InvalidTaskException. if we raise it here as
+            # InvalidTaskException, then "Task config is invalid: "
+            # gets prepended to the message twice.
+            raise Exception(_("Input task is empty"))
+
+        self.version = self._get_version(config)
+        self._validate_version()
+        self._validate_json(config)
+
+        self.title = config.get("title", "Task")
+        self.tags = config.get("tags", [])
+        self.description = config.get("description")
+
+        self.subtasks = self._make_subtasks(config)
+
+        # if self.version == 1:
+        # TODO(ikhudoshyn): Warn user about deprecated format
+
+    @staticmethod
+    def _get_version(config):
+        return config.get("version", 1)
+
+    def _validate_version(self):
+        if self.version not in self.CONFIG_SCHEMAS:
+            allowed = ", ".join([str(k) for k in self.CONFIG_SCHEMAS])
+            msg = (_("Task configuration version {0} is not supported. "
+                     "Supported versions: {1}")).format(self.version, allowed)
+            raise exceptions.InvalidTaskException(msg)
+
+    def _validate_json(self, config):
+        try:
+            jsonschema.validate(config, self.CONFIG_SCHEMAS[self.version])
+        except Exception as e:
+            raise exceptions.InvalidTaskException(str(e))
+
+    def _make_subtasks(self, config):
+        if self.version == 2:
+            return [SubTask(s) for s in config["subtasks"]]
+        elif self.version == 1:
+            subtasks = []
+            for name, v1_workloads in config.items():
+                for v1_workload in v1_workloads:
+                    v2_workload = copy.deepcopy(v1_workload)
+                    v2_workload["name"] = name
+                    subtasks.append(
+                        SubTask({"title": name, "workloads": [v2_workload]}))
+            return subtasks
+
+
+class SubTask(object):
+    """Subtask -- unit of execution in Task
+
+    """
+    def __init__(self, config):
+        """Subtask constructor.
+
+        :param config: Dict with configuration of specified subtask
+        """
+        self.title = config["title"]
+        self.tags = config.get("tags", [])
+        self.group = config.get("group")
+        self.description = config.get("description")
+        self.workloads = [Workload(wconf)
+                          for wconf
+                          in config["workloads"]]
+        self.context = config.get("context", {})
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "description": self.description,
+            "context": self.context,
+        }
+
+
+class Workload(object):
+    """Workload -- workload configuration in SubTask.
+
+    """
+    def __init__(self, config):
+        self.name = config["name"]
+        self.runner = config.get("runner", {})
+        self.sla = config.get("sla", {})
+        self.hooks = config.get("hooks", [])
+        self.context = config.get("context", {})
+        self.args = config.get("args", {})
+
+    def to_dict(self):
+        workload = {"runner": self.runner}
+
+        for prop in "sla", "args", "context", "hooks":
+            value = getattr(self, prop)
+            if value:
+                workload[prop] = value
+
+        return workload
+
+    def to_task(self):
+        """Make task configuration for the workload.
+
+        This method returns a dict representing full configuration
+        of the task containing a single subtask with this single
+        workload.
+
+        :return: dict containing full task configuration
+        """
+        # NOTE(ikhudoshyn): Result of this method will be used
+        # to store full task configuration in DB so that
+        # subtask configuration in reports would be given
+        # in the same format as it was provided by user.
+        # Temporarily it returns to_dict() in order not
+        # to break existing reports. It should be
+        # properly implemented in a patch that will update reports.
+        # return {self.name: [self.to_dict()]}
+        return self.to_dict()
+
+    def make_key(self, pos):
+        return {"name": self.name,
+                "pos": pos,
+                "kw": self.to_task()}
+
+    def make_exception_args(self, pos, reason):
+        return {"name": self.name,
+                "pos": pos,
+                "config": self.to_dict(),
+                "reason": reason}


### PR DESCRIPTION
These two files help to capture neutron api calltrace with rally scenario tests.

Manual cahnges needed -
In engine.py, pids has to be updated with process ids of neutron-servers(which represent api workers).

When we run the rally task, for example,
rally task start samples/tasks/scenarios/neutron/create-and-list-ports.yaml

calltrace file will be generated at /tmp/rally/<task-id>/calltrace